### PR TITLE
Faster DWD OpenData download

### DIFF
--- a/docs/source/quick-start/examples.rst
+++ b/docs/source/quick-start/examples.rst
@@ -16,7 +16,8 @@ Basic Example
                              init_time=0,
                              forecast_hour=[24],
                              dest=args.data,
-                             merge_files=True)
+                             merge_files=True,
+                             validate_urls=True)
 
 
     

--- a/docs/source/user-guide/opendata.rst
+++ b/docs/source/user-guide/opendata.rst
@@ -30,7 +30,8 @@ This small example downloads total precipitation data from ICON-EU for 0,6,12,18
                              init_time=0,
                              forecast_hour=[0,6,12,18,24],
                              dest="data",
-                             merge_files=True)
+                             merge_files=True,
+                             validate_urls=True)
 
 
 

--- a/enstools/opendata/DWDContent.py
+++ b/enstools/opendata/DWDContent.py
@@ -378,6 +378,10 @@ class DWDContent:
         init_time:  int or datetime or list of int or datetime
                     if an integer is given, the column init_time is used. For da datetime object
                     the column abs_init_time is used.
+                    
+        content:    pandas.DataFrame
+                    Reference to the content to select from. If None, self.content is chosen.
+                    Can also be a subset of the content for more efficient parsing.
         Returns
         -------
         Series:

--- a/enstools/opendata/DWDRadar.py
+++ b/enstools/opendata/DWDRadar.py
@@ -320,7 +320,7 @@ class DWDRadar:
                                                  forecast_time=ftime, file_format=file_format)
         return total_size
 
-    def check_parameters(self, product=None, data_time=None, forecast_time=None, file_format=None):
+    def check_parameters(self, product=None, data_time=None, forecast_time=None, file_format=None, check_urls=True):
         """
         Checks if there are all files available for the given parameters.
         If not, the DWDRadar object will be refreshed.
@@ -336,6 +336,9 @@ class DWDRadar:
             The minutes since the data_time of the radar data.
         file_format: str
             The file format (eg. 'gz').
+        check_urls: bool
+            Whether to ping all download URLs to check their availability. 
+            Might take a while with high-dimensional data sets.
 
         Returns
         -------
@@ -360,7 +363,7 @@ class DWDRadar:
 
         if not params_available:
             logging.warning("Parameters not available")
-        else:
+        elif check_urls:
             for dtime in data_time:
                 for ftime in forecast_time:
                     if not self.check_url_available(product=product, data_time=dtime,
@@ -387,7 +390,7 @@ class DWDRadar:
                         raise ValueError("The forecast time {} is not available for the data time {}. "
                                          "Possible values:{}".format(ftime, dtime, avail_forecast_times))
 
-    def retrieve(self, product=None, data_time=None, forecast_time=0, dest=None, file_format=None):
+    def retrieve(self, product=None, data_time=None, forecast_time=0, dest=None, file_format=None, validate_urls=True):
         """
         Downloads datasets from opendata server.
         Parameters
@@ -408,6 +411,11 @@ class DWDRadar:
                 Destination folder for downloaded data. If the files are already available,
                 they are not downloaded again.
 
+        validate_urls : bool
+                Whether to ping all download URLs first before starting to download the data. 
+                Updates the cache if some URLs are not there. Considering setting this flag to 
+                False for faster downloads, especially if you download sizeable amounts.
+                
         Returns
         -------
         list :
@@ -437,7 +445,7 @@ class DWDRadar:
         download_urls = []
 
         self.check_parameters(product=product, data_time=data_time,
-                              forecast_time=forecast_time, file_format=file_format)
+                              forecast_time=forecast_time, file_format=file_format, check_urls=validate_urls)
         for dtime in data_time:
             for ftime in forecast_time:
                 download_urls.append(self.get_url(product=product, data_time=dtime,

--- a/enstools/opendata/cli.py
+++ b/enstools/opendata/cli.py
@@ -62,7 +62,8 @@ def retrieve_data(args):
                              init_time=args.init_time,
                              forecast_hour=args.lead_time,
                              dest=args.dest,
-                             merge_files=args.merge)
+                             merge_files=args.merge, 
+                             validate_urls=not args.skip_url_validation)
         for one_file in files:
             logging.info(f"downloaded: {one_file}")
     except ValueError as ve:
@@ -194,6 +195,7 @@ def get_parser():
     parser_retrieve = subparsers.add_parser("retrieve", help="download files from an opendata service provider")
     parser_retrieve.add_argument("--dest", help="destination folder for downloaded data.")
     parser_retrieve.add_argument("--merge", action='store_true', help="merge multiple downloaded files.")
+    parser_retrieve.add_argument("--skip-url-validation", action='store_true', help="enables skipping of validating all download URLs before starting to download them.")
     __add_common_args(parser_retrieve)
     parser_retrieve.set_defaults(func=retrieve_data)
 

--- a/enstools/opendata/retrieve_nwp.py
+++ b/enstools/opendata/retrieve_nwp.py
@@ -2,7 +2,7 @@ from .DWDContent import getDWDContent
 
 
 def retrieve_nwp(service="DWD", model="ICON", eps=None, grid_type=None, variable=None, level_type=None,
-                 levels=0, init_time=None, forecast_hour=None, merge_files=False, dest=None):
+                 levels=0, init_time=None, forecast_hour=None, merge_files=False, dest=None, validate_urls=True):
     """
     Downloads numerical weather prediction (NWP) datasets from opendata server.
     
@@ -39,6 +39,10 @@ def retrieve_nwp(service="DWD", model="ICON", eps=None, grid_type=None, variable
     dest : str
             Destination folder for downloaded data. If the files are already available,
             they are not downloaded again.
+            
+    validate_urls : bool
+            Whether to ping all download URLs first to validate state of the cache. Might slow
+            down the process significantly for bigger data requests.
 
     Returns
     -------
@@ -49,5 +53,5 @@ def retrieve_nwp(service="DWD", model="ICON", eps=None, grid_type=None, variable
     download_files = content.retrieve(service=service, model=model, eps=eps, grid_type=grid_type,
                                                variable=variable, level_type=level_type, levels=levels,
                                                init_time=init_time, forecast_hour=forecast_hour,
-                                               merge_files=merge_files, dest=dest)
+                                               merge_files=merge_files, dest=dest, validate_urls=validate_urls)
     return download_files

--- a/enstools/opendata/retrieve_radar.py
+++ b/enstools/opendata/retrieve_radar.py
@@ -1,7 +1,7 @@
 from .DWDRadar import getDWDRadar
 
 
-def retrieve_radar(product=None, data_time=None, forecast_time=0, dest=None, file_format=None):
+def retrieve_radar(product=None, data_time=None, forecast_time=0, dest=None, file_format=None, validate_urls=True):
     """
     Downloads radar datasets from opendata server.
     
@@ -22,6 +22,10 @@ def retrieve_radar(product=None, data_time=None, forecast_time=0, dest=None, fil
         file_format: str
             The file format (eg. 'gz'). Only has to be specified when there are more than one available.
 
+        validate_urls : bool
+                Whether to ping all download URLs first to validate state of the cache. Might slow
+                down the process significantly for bigger data requests.
+                
         Returns
         -------
         list :
@@ -30,5 +34,5 @@ def retrieve_radar(product=None, data_time=None, forecast_time=0, dest=None, fil
     """
     content = getDWDRadar()
     download_files = content.retrieve(product=product, data_time=data_time, forecast_time=forecast_time,
-                                      dest=dest, file_format=file_format)
+                                      dest=dest, file_format=file_format, validate_urls=validate_urls)
     return download_files


### PR DESCRIPTION
Speeds up the duration of `retrieve` calls by:
- More efficient block queries to the data frame instead of querying single elements
- Less queries when validating whether the queried variables, times etc. are in the local data frame
- Made the "URL check" optional: Currently, all download URLs are pinged beforehand to check for availability and whether to update the cache. This is neccessary, if the init time is given as integer (e.g., 0) for 00 UTC, since the date can't be deducted and the 00 UTC data in the cache might not be available at the remote. But when the init time is given as datetime, this can be optionally skipped. For example, one forecast (20 time steps) with 60 model levels and 5 variables would query 6000 URLs. Given a server response time of ~0.3s, this URL check (before the download even starts) takes around 20 minutes. Added flags to skip this URL check when the init time is given in datetime for both Python API and CLI.
- Updated documentation accordingly.